### PR TITLE
Rounding of the user's current level to 2 decimal places in the xp ca…

### DIFF
--- a/client/src/components/pages/calculator/Calculator.tsx
+++ b/client/src/components/pages/calculator/Calculator.tsx
@@ -122,7 +122,7 @@ export function Calculator() {
                         min="0"
                         max="50"
                         placeholder="Your current level"
-                        value={isNaN(level) ? "" : level}
+                        value={isNaN(level) ? "" : level.toFixed(2)}
                         onChange={handleLevelChange}
                       />
                     </div>


### PR DESCRIPTION
This PR implements the rounding of the user's current level in the XP calculator to improve the accuracy and consistency of displayed results. Previously, the current level could display more than two decimal places, which could give an impression of confusion or excessive precision.