### PR TITLE
Refactor tailwind.config.js to use ES module syntax

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   darkMode: ["class"],
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
@@ -64,5 +64,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [import("tailwindcss-animate")],
 };


### PR DESCRIPTION
This pull request includes changes to the `client/tailwind.config.js` file to update the module export style and modify the plugin import method.

Updates to module export and plugin import:

* [`client/tailwind.config.js`](diffhunk://#diff-c161da30d9a464d0e8adede24e77041c08ea806f0ea5e7547344f60a2e0099fcL2-R2): Changed the module export from `module.exports` to `export default`.
* [`client/tailwind.config.js`](diffhunk://#diff-c161da30d9a464d0e8adede24e77041c08ea806f0ea5e7547344f60a2e0099fcL67-R67): Updated the plugin import method from `require` to `import`.